### PR TITLE
Initial version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 dist
+
+.npm-debug.log

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,0 +1,5 @@
+# React Radial List Release History
+
+## 1.0.0
+
+Initial release

--- a/README.md
+++ b/README.md
@@ -1,0 +1,65 @@
+# React Radial List
+
+If you've ever needed to arrange a list of items (links, buttons, elements) in a circular pattern,
+you'll know that it's kind of a fiddly process. This style-agnostic component does exactly what it
+says on the tin. Pass it an array of React-renderable nodes, and it will wrap them in an unordered
+list with CSS transforms to arrange them radially inside a container.
+
+## Installation
+
+There are two ways to get `react-radial-list`: via the CDN, or via `npm`.
+
+CDN:
+
+```
+<script type="application/javascript" src="https://d1ig6folwd6a9s.cloudfront.net/react-radial-list.1.0.0.js"></script>
+```
+
+NPM:
+
+```
+npm install react-radial-list
+```
+
+...and import into your file:
+
+```js
+import ReactRadialList from 'react-radial-list'
+
+// Your code...
+```
+
+Since you're probably bundling your own javascript assets, I'd generally recommend using `npm`.
+
+## Usage
+
+In either case, you can create a radial list by passing the component a list of elements to render,
+as well as the optional parameters you want to customise the output:
+
+```js
+const items = [
+  <div id="item-1">Item One</div>,
+  <div id="item-2">Item Two</div>,
+  <div id="item-3">Item Three</div>,
+  <div id="item-4">Item Four</div>,
+  <div id="item-5">Item Five</div>
+]
+
+<ReactRadialList
+  items={items} // Required
+  diameter={240} // Diameter of the radial list, a number of pixels or a CSS value e.g. '50%'
+  offsetDegrees={-90} // Rotation offset: -90 default puts the first item into 12 o'clock position
+  listStyles={{}} // If
+  itemStyles={{}}
+/>
+```
+
+## Customising and Theming
+
+Internally, `react-radial-list` uses the excellent [cxs](https://github.com/jxnblk/cxs) library for
+creating a dynamic modular stylesheet from javascript objects. You can provide your own js style
+object for the list itself and each item by passing an object as the `listStyles` and `itemStyles`
+props respectively.
+
+If you prefer to use a more traditional approach to styling, use the class hook `.radial-list` to
+provide styles for the list, and `.radial-list-item` to style each list item.

--- a/npm-debug.log
+++ b/npm-debug.log
@@ -1,0 +1,109 @@
+0 info it worked if it ends with ok
+1 verbose cli [ '/usr/local/bin/node',
+1 verbose cli   '/usr/local/bin/npm',
+1 verbose cli   'install',
+1 verbose cli   'inlin-style-prefixer',
+1 verbose cli   '--save-dev' ]
+2 info using npm@3.10.8
+3 info using node@v6.8.1
+4 silly loadCurrentTree Starting
+5 silly install loadCurrentTree
+6 silly install readLocalPackageData
+7 silly fetchPackageMetaData inlin-style-prefixer
+8 silly fetchNamedPackageData inlin-style-prefixer
+9 silly mapToRegistry name inlin-style-prefixer
+10 silly mapToRegistry using default registry
+11 silly mapToRegistry registry https://registry.npmjs.org/
+12 silly mapToRegistry data Result {
+12 silly mapToRegistry   raw: 'inlin-style-prefixer',
+12 silly mapToRegistry   scope: null,
+12 silly mapToRegistry   escapedName: 'inlin-style-prefixer',
+12 silly mapToRegistry   name: 'inlin-style-prefixer',
+12 silly mapToRegistry   rawSpec: '',
+12 silly mapToRegistry   spec: 'latest',
+12 silly mapToRegistry   type: 'tag' }
+13 silly mapToRegistry uri https://registry.npmjs.org/inlin-style-prefixer
+14 verbose request uri https://registry.npmjs.org/inlin-style-prefixer
+15 verbose request no auth needed
+16 info attempt registry request try #1 at 2:14:01 PM
+17 verbose request using bearer token for auth
+18 verbose request id ae11ad5f0c579a3e
+19 http request GET https://registry.npmjs.org/inlin-style-prefixer
+20 http 404 https://registry.npmjs.org/inlin-style-prefixer
+21 verbose headers { 'content-type': 'application/json',
+21 verbose headers   'cache-control': 'max-age=0',
+21 verbose headers   'content-length': '2',
+21 verbose headers   'accept-ranges': 'bytes',
+21 verbose headers   date: 'Tue, 18 Oct 2016 04:14:02 GMT',
+21 verbose headers   via: '1.1 varnish',
+21 verbose headers   connection: 'keep-alive',
+21 verbose headers   'x-served-by': 'cache-hkg6822-HKG',
+21 verbose headers   'x-cache': 'MISS',
+21 verbose headers   'x-cache-hits': '0',
+21 verbose headers   'x-timer': 'S1476764042.014972,VS0,VE236',
+21 verbose headers   vary: 'Accept-Encoding' }
+22 silly get cb [ 404,
+22 silly get   { 'content-type': 'application/json',
+22 silly get     'cache-control': 'max-age=0',
+22 silly get     'content-length': '2',
+22 silly get     'accept-ranges': 'bytes',
+22 silly get     date: 'Tue, 18 Oct 2016 04:14:02 GMT',
+22 silly get     via: '1.1 varnish',
+22 silly get     connection: 'keep-alive',
+22 silly get     'x-served-by': 'cache-hkg6822-HKG',
+22 silly get     'x-cache': 'MISS',
+22 silly get     'x-cache-hits': '0',
+22 silly get     'x-timer': 'S1476764042.014972,VS0,VE236',
+22 silly get     vary: 'Accept-Encoding' } ]
+23 silly fetchPackageMetaData Error: Registry returned 404 for GET on https://registry.npmjs.org/inlin-style-prefixer
+23 silly fetchPackageMetaData     at makeError (/usr/local/lib/node_modules/npm/node_modules/npm-registry-client/lib/request.js:302:12)
+23 silly fetchPackageMetaData     at CachingRegistryClient.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/npm-registry-client/lib/request.js:280:14)
+23 silly fetchPackageMetaData     at Request._callback (/usr/local/lib/node_modules/npm/node_modules/npm-registry-client/lib/request.js:210:14)
+23 silly fetchPackageMetaData     at Request.self.callback (/usr/local/lib/node_modules/npm/node_modules/request/request.js:187:22)
+23 silly fetchPackageMetaData     at emitTwo (events.js:106:13)
+23 silly fetchPackageMetaData     at Request.emit (events.js:191:7)
+23 silly fetchPackageMetaData     at Request.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/request/request.js:1044:10)
+23 silly fetchPackageMetaData     at emitOne (events.js:96:13)
+23 silly fetchPackageMetaData     at Request.emit (events.js:188:7)
+23 silly fetchPackageMetaData     at IncomingMessage.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/request/request.js:965:12)
+23 silly fetchPackageMetaData  error for inlin-style-prefixer { Error: Registry returned 404 for GET on https://registry.npmjs.org/inlin-style-prefixer
+23 silly fetchPackageMetaData     at makeError (/usr/local/lib/node_modules/npm/node_modules/npm-registry-client/lib/request.js:302:12)
+23 silly fetchPackageMetaData     at CachingRegistryClient.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/npm-registry-client/lib/request.js:280:14)
+23 silly fetchPackageMetaData     at Request._callback (/usr/local/lib/node_modules/npm/node_modules/npm-registry-client/lib/request.js:210:14)
+23 silly fetchPackageMetaData     at Request.self.callback (/usr/local/lib/node_modules/npm/node_modules/request/request.js:187:22)
+23 silly fetchPackageMetaData     at emitTwo (events.js:106:13)
+23 silly fetchPackageMetaData     at Request.emit (events.js:191:7)
+23 silly fetchPackageMetaData     at Request.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/request/request.js:1044:10)
+23 silly fetchPackageMetaData     at emitOne (events.js:96:13)
+23 silly fetchPackageMetaData     at Request.emit (events.js:188:7)
+23 silly fetchPackageMetaData     at IncomingMessage.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/request/request.js:965:12) pkgid: 'inlin-style-prefixer', statusCode: 404, code: 'E404' }
+24 silly rollbackFailedOptional Starting
+25 silly rollbackFailedOptional Finishing
+26 silly runTopLevelLifecycles Finishing
+27 silly install printInstalled
+28 verbose stack Error: Registry returned 404 for GET on https://registry.npmjs.org/inlin-style-prefixer
+28 verbose stack     at makeError (/usr/local/lib/node_modules/npm/node_modules/npm-registry-client/lib/request.js:302:12)
+28 verbose stack     at CachingRegistryClient.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/npm-registry-client/lib/request.js:280:14)
+28 verbose stack     at Request._callback (/usr/local/lib/node_modules/npm/node_modules/npm-registry-client/lib/request.js:210:14)
+28 verbose stack     at Request.self.callback (/usr/local/lib/node_modules/npm/node_modules/request/request.js:187:22)
+28 verbose stack     at emitTwo (events.js:106:13)
+28 verbose stack     at Request.emit (events.js:191:7)
+28 verbose stack     at Request.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/request/request.js:1044:10)
+28 verbose stack     at emitOne (events.js:96:13)
+28 verbose stack     at Request.emit (events.js:188:7)
+28 verbose stack     at IncomingMessage.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/request/request.js:965:12)
+29 verbose statusCode 404
+30 verbose pkgid inlin-style-prefixer
+31 verbose cwd /Users/justin/code/react-radial-list
+32 error Darwin 16.1.0
+33 error argv "/usr/local/bin/node" "/usr/local/bin/npm" "install" "inlin-style-prefixer" "--save-dev"
+34 error node v6.8.1
+35 error npm  v3.10.8
+36 error code E404
+37 error 404 Registry returned 404 for GET on https://registry.npmjs.org/inlin-style-prefixer
+38 error 404
+39 error 404 'inlin-style-prefixer' is not in the npm registry.
+40 error 404 You should bug the author to publish it (or use the name yourself!)
+41 error 404 Note that you can also install from a
+42 error 404 tarball, folder, http url, or git url.
+43 verbose exit [ 1, true ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-radial-list",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "React component that lays out a list of children in a radial pattern.",
   "main": "dist/module/RadialList/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,13 @@
   "description": "React component that lays out a list of children in a radial pattern.",
   "main": "source/client.js",
   "scripts": {
-    "test": "ava"
+    "start": "brb serve",
+    "build": "brb build",
+    "lint": "brb lint",
+    "lint:fix": "brb lint --fix",
+    "lint:watch": "brb lint --watch",
+    "test": "ava",
+    "test:watch": "ava --watch"
   },
   "repository": {
     "type": "git",
@@ -23,8 +29,28 @@
   "homepage": "https://github.com/everydayhero/react-radial-list#readme",
   "devDependencies": {
     "ava": "^0.16.0",
+    "babel-polyfill": "^6.16.0",
     "boiler-room-builder": "^1.0.0-18",
     "cxs": "^1.0.1",
-    "enzyme": "^2.4.1"
+    "enzyme": "^2.4.1",
+    "escape-string-regexp": "^1.0.5",
+    "jsdom": "^9.6.0"
+  },
+  "babel": {
+    "presets": [
+      "es2015",
+      "stage-0",
+      "react"
+    ]
+  },
+  "ava": {
+    "files": [
+      "source/**/__tests__/*.js"
+    ],
+    "require": [
+      "babel-register",
+      "./test/dom"
+    ],
+    "babel": "inherit"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,13 +2,12 @@
   "name": "react-radial-list",
   "version": "1.0.0",
   "description": "React component that lays out a list of children in a radial pattern.",
-  "main": "source/client.js",
+  "main": "dist/module/RadialList/index.js",
   "scripts": {
     "start": "brb serve",
     "build": "brb build",
+    "prepublish": "brb build && babel source/components --out-dir dist/module",
     "lint": "brb lint",
-    "lint:fix": "brb lint --fix",
-    "lint:watch": "brb lint --watch",
     "test": "ava",
     "test:watch": "ava --watch"
   },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "ava": "^0.16.0",
     "babel-polyfill": "^6.16.0",
+    "babel-preset-latest": "^6.16.0",
     "boiler-room-builder": "^1.0.0-18",
     "cxs": "^1.0.1",
     "enzyme": "^2.4.1",
@@ -37,8 +38,7 @@
   },
   "babel": {
     "presets": [
-      "es2015",
-      "stage-0",
+      "latest",
       "react"
     ]
   },

--- a/source/client.js
+++ b/source/client.js
@@ -5,4 +5,18 @@ import RadialList from './components/RadialList'
 
 const mount = document.getElementById('mount')
 
-render(<RadialList />, mount)
+const items = [
+  <div id='item-1'>0</div>,
+  <div id='item-1'>1</div>,
+  <div id='item-1'>2</div>,
+  <div id='item-1'>3</div>,
+  <div id='item-1'>4</div>,
+  <div id='item-1'>5</div>,
+  <div id='item-1'>6</div>,
+  <div id='item-1'>7</div>,
+  <div id='item-1'>8</div>,
+  <div id='item-1'>9</div>,
+  <div id='item-1'>10</div>
+]
+
+render(<RadialList items={items} offsetDegrees={106.5} />, mount)

--- a/source/components/RadialList/__tests__/RadialList-test.js
+++ b/source/components/RadialList/__tests__/RadialList-test.js
@@ -1,7 +1,75 @@
+import React from 'react'
 import test from 'ava'
+import { shallow } from 'enzyme'
 
+import { renderAndExtractClassnames, hasStyle } from '../../../../test/styleInspection'
+import RadialListItem from '../../RadialListItem'
 import RadialList from '../'
 
-test('Testing works', t => {
-  t.is(1 + 1, 2)
+const TEST_ITEMS = [
+  <div id='item-1'>Item One</div>,
+  <div id='item-2'>Item Two</div>,
+  <div id='item-3'>Item Three</div>,
+  <div id='item-4'>Item Four</div>,
+  <div id='item-5'>Item Five</div>
+]
+
+test('Renders as an unordered list', t => {
+  const wrapper = shallow(<RadialList items={TEST_ITEMS} />)
+
+  t.true(wrapper.is('ul.radial-list'))
+})
+
+test('Renders a RadialListItem for each of props.items', t => {
+  const wrapper = shallow(<RadialList items={TEST_ITEMS} />)
+  const radialListItems = wrapper.find(RadialListItem)
+
+  t.is(radialListItems.length, 5)
+})
+
+test('Provides the correct props to each RadialListItem', t => {
+  const wrapper = shallow(
+    <RadialList
+      items={TEST_ITEMS}
+      offsetDegrees={180}
+    />
+  )
+  const radialListItems = wrapper.find(RadialListItem)
+
+  radialListItems.forEach((node, index) => {
+    t.is(node.prop('item'), TEST_ITEMS[index])
+    t.is(node.prop('index'), index)
+    t.is(node.prop('count'), TEST_ITEMS.length)
+    t.is(node.prop('offsetDegrees'), 180)
+  })
+})
+
+test('Passes optional itemStyles onto each RadialListItem', t => {
+  const testStyles = {
+    color: 'red',
+    border: '1px solid red'
+  }
+  const wrapper = shallow(
+    <RadialList
+      items={TEST_ITEMS}
+      itemStyles={testStyles}
+    />
+  )
+  const radialListItems = wrapper.find(RadialListItem)
+
+  radialListItems.forEach((node, index) => {
+    t.is(node.prop('itemStyles'), testStyles)
+  })
+})
+
+test('Renders optional listStyles onto the list', t => {
+  const testStyles = {
+    color: 'red',
+    border: '1px solid red'
+  }
+  const radialList = <RadialList items={TEST_ITEMS} listStyles={testStyles} />
+  const classNames = renderAndExtractClassnames(radialList, 'ul')
+
+  t.true(hasStyle(classNames, 'color', 'red'))
+  t.true(hasStyle(classNames, 'border', '1px solid red'))
 })

--- a/source/components/RadialList/__tests__/RadialList-test.js
+++ b/source/components/RadialList/__tests__/RadialList-test.js
@@ -1,0 +1,7 @@
+import test from 'ava'
+
+import RadialList from '../'
+
+test('Testing works', t => {
+  t.is(1 + 1, 2)
+})

--- a/source/components/RadialList/index.js
+++ b/source/components/RadialList/index.js
@@ -1,29 +1,25 @@
 import React from 'react'
-import cxs from 'cxs'
 
+import styles from './styles'
+import css from '../../css'
 import RadialListItem from '../RadialListItem'
-
-const BASE_STYLES = {
-  display: 'block',
-  position: 'relative',
-  margin: 0,
-  padding: 0
-}
 
 const RadialList = ({
   items,
+  selectedItemIndex,
   diameter = 240, // By default renders around circle with a diameter of 240px
   offsetDegrees = -90, // Positions the first item at 12 o'clock
   listStyles = {},
-  itemStyles = {}
+  itemStyles = {},
+  collapsed = false
 }) => {
-  const styles = Object.assign({}, BASE_STYLES, {
+  const listStyles = css(styles.list, {
     width: diameter,
     height: diameter
   }, listStyles)
 
   return (
-    <ul className={`radial-list ${cxs(styles)}`}>
+    <ul className={`radial-list ${listStyles}`}>
       {items.map((item, i) => (
         <RadialListItem
           key={i}
@@ -32,6 +28,8 @@ const RadialList = ({
           count={items.length}
           offsetDegrees={offsetDegrees}
           itemStyles={itemStyles}
+          selected={i === selectedItemIndex}
+          collapsed={collapsed}
         />
       ))}
     </ul>

--- a/source/components/RadialList/index.js
+++ b/source/components/RadialList/index.js
@@ -16,9 +16,9 @@ const BASE_STYLES = {
 
 const RadialList = ({
   items,
-  offsetDegrees,
-  listStyles,
-  itemStyles
+  offsetDegrees = -90, // Positions the first item at 12 o'clock
+  listStyles = {},
+  itemStyles = {}
 }) => {
   const styles = Object.assign({}, BASE_STYLES, listStyles)
 
@@ -43,12 +43,6 @@ RadialList.propTypes = {
   offsetDegrees: React.PropTypes.number,
   listStyles: React.PropTypes.object,
   itemStyles: React.PropTypes.object
-}
-
-RadialList.defaultProps = {
-  offsetDegrees: -90, // Positions the first item at 12 o'clock
-  listStyles: {},
-  itemStyles: {}
 }
 
 export default RadialList

--- a/source/components/RadialList/index.js
+++ b/source/components/RadialList/index.js
@@ -6,21 +6,21 @@ import RadialListItem from '../RadialListItem'
 const BASE_STYLES = {
   display: 'block',
   position: 'relative',
-  // width: '100%',
-  // height: '100%'
-  width: '240px',
-  height: '240px',
   margin: 0,
   padding: 0
 }
 
 const RadialList = ({
   items,
+  diameter = 240, // By default renders around circle with a diameter of 240px
   offsetDegrees = -90, // Positions the first item at 12 o'clock
   listStyles = {},
   itemStyles = {}
 }) => {
-  const styles = Object.assign({}, BASE_STYLES, listStyles)
+  const styles = Object.assign({}, BASE_STYLES, {
+    width: diameter,
+    height: diameter
+  }, listStyles)
 
   return (
     <ul className={`radial-list ${cxs(styles)}`}>
@@ -40,6 +40,10 @@ const RadialList = ({
 
 RadialList.propTypes = {
   items: React.PropTypes.arrayOf(React.PropTypes.node).isRequired,
+  diameter: React.PropTypes.oneOf([
+    React.PropTypes.number,
+    React.PropTypes.string
+  ]),
   offsetDegrees: React.PropTypes.number,
   listStyles: React.PropTypes.object,
   itemStyles: React.PropTypes.object

--- a/source/components/RadialList/index.js
+++ b/source/components/RadialList/index.js
@@ -1,13 +1,54 @@
 import React from 'react'
+import cxs from 'cxs'
+
+import RadialListItem from '../RadialListItem'
+
+const BASE_STYLES = {
+  display: 'block',
+  position: 'relative',
+  // width: '100%',
+  // height: '100%'
+  width: '240px',
+  height: '240px',
+  margin: 0,
+  padding: 0
+}
 
 const RadialList = ({
-  items
+  items,
+  offsetDegrees,
+  listStyles,
+  itemStyles
 }) => {
+  const styles = Object.assign({}, BASE_STYLES, listStyles)
 
+  return (
+    <ul className={`radial-list ${cxs(styles)}`}>
+      {items.map((item, i) => (
+        <RadialListItem
+          key={i}
+          item={item}
+          index={i}
+          count={items.length}
+          offsetDegrees={offsetDegrees}
+          itemStyles={itemStyles}
+        />
+      ))}
+    </ul>
+  )
 }
 
 RadialList.propTypes = {
-  items: React.PropTypes.arrayOf(React.PropTypes.node).required
+  items: React.PropTypes.arrayOf(React.PropTypes.node).isRequired,
+  offsetDegrees: React.PropTypes.number,
+  listStyles: React.PropTypes.object,
+  itemStyles: React.PropTypes.object
+}
+
+RadialList.defaultProps = {
+  offsetDegrees: -90, // Positions the first item at 12 o'clock
+  listStyles: {},
+  itemStyles: {}
 }
 
 export default RadialList

--- a/source/components/RadialList/styles.js
+++ b/source/components/RadialList/styles.js
@@ -1,0 +1,8 @@
+export default {
+  list: {
+    display: 'block',
+    position: 'relative',
+    margin: 0,
+    padding: 0
+  }
+}

--- a/source/components/RadialListItem/__tests__/RadialListItem-test.js
+++ b/source/components/RadialListItem/__tests__/RadialListItem-test.js
@@ -1,0 +1,69 @@
+import React from 'react'
+import test from 'ava'
+import { shallow } from 'enzyme'
+import cxs from 'cxs'
+import escapeStringRegexp from 'escape-string-regexp'
+
+import RadialListItem from '../'
+
+test('renders the item inside a list/span container', t => {
+  const item = <div className='test-item'>Test Item</div>
+  const wrapper = shallow(
+    <RadialListItem
+      item={item}
+      index={0}
+      count={6}
+    />
+  )
+
+  const listItem = wrapper.find('li.radial-list-item')
+  t.true(listItem.length === 1)
+  t.true(listItem.find('span').length === 1)
+  t.true(listItem.find('span').contains(item))
+})
+
+test('sets the transform offset styles so the li will rotate around a central point', t => {
+  const item = <div className='test-item'>Test Item</div>
+  let classNames = renderAndExtractClassnames(item, 0, 6)
+  t.true(hasStyle(classNames, 'transform', 'rotate(0deg)'))
+
+  classNames = renderAndExtractClassnames(item, 1, 6)
+  t.true(hasStyle(classNames, 'transform', 'rotate(60deg)'))
+
+  classNames = renderAndExtractClassnames(item, 2, 6)
+  t.true(hasStyle(classNames, 'transform', 'rotate(120deg)'))
+})
+
+test('counter-rotates the internal span so the elements render upright', t => {
+  const item = <div className='test-item'>Test Item</div>
+
+  let classNames = renderAndExtractClassnames(item, 1, 6, '.radial-list-item-content')
+  t.true(hasStyle(classNames, 'transform', 'rotate(-60deg)'))
+
+  classNames = renderAndExtractClassnames(item, 2, 6, '.radial-list-item-content')
+  t.true(hasStyle(classNames, 'transform', 'rotate(-120deg)'))
+})
+
+const hasStyle = (classNameKeys, key, value) => {
+  return cxs.rules
+    .filter(rule => classNameKeys.includes(rule.id) && rule.css.includes(key))
+    .reduce((prev, current) => {
+      const keyValPat = `${escapeStringRegexp(key)}\\s*:\\s*${escapeStringRegexp(value)}`
+      return prev || !!current.css.match(new RegExp(keyValPat))
+    }, false)
+}
+
+const cxsClassNames = classNames => {
+  return classNames.split(' ').filter(cn => cn.includes('cxs-'))
+}
+
+const renderAndExtractClassnames = (item, index, count, selector = 'li') => {
+  const wrapper = shallow(
+    <RadialListItem
+      item={item}
+      index={index}
+      count={count}
+    />
+  )
+  return cxsClassNames(wrapper.find(selector).prop('className'))
+}

--- a/source/components/RadialListItem/__tests__/RadialListItem-test.js
+++ b/source/components/RadialListItem/__tests__/RadialListItem-test.js
@@ -1,9 +1,8 @@
 import React from 'react'
 import test from 'ava'
 import { shallow } from 'enzyme'
-import cxs from 'cxs'
-import escapeStringRegexp from 'escape-string-regexp'
 
+import { renderAndExtractClassnames, hasStyle } from '../../../../test/styleInspection'
 import RadialListItem from '../'
 
 test('renders the item inside a list/span container', t => {
@@ -23,47 +22,34 @@ test('renders the item inside a list/span container', t => {
 })
 
 test('sets the transform offset styles so the li will rotate around a central point', t => {
-  const item = <div className='test-item'>Test Item</div>
-  let classNames = renderAndExtractClassnames(item, 0, 6)
+  let item = radialListItem(<div className='test-item'>Test Item</div>, 0, 6)
+  let classNames = renderAndExtractClassnames(item)
   t.true(hasStyle(classNames, 'transform', 'rotate(0deg)'))
 
-  classNames = renderAndExtractClassnames(item, 1, 6)
+  item = radialListItem(<div className='test-item'>Test Item</div>, 1, 6)
+  classNames = renderAndExtractClassnames(item)
   t.true(hasStyle(classNames, 'transform', 'rotate(60deg)'))
 
-  classNames = renderAndExtractClassnames(item, 2, 6)
+  item = radialListItem(<div className='test-item'>Test Item</div>, 2, 6)
+  classNames = renderAndExtractClassnames(item)
   t.true(hasStyle(classNames, 'transform', 'rotate(120deg)'))
 })
 
 test('counter-rotates the internal span so the elements render upright', t => {
-  const item = <div className='test-item'>Test Item</div>
+  let item = radialListItem(<div className='test-item'>Test Item</div>, 1, 6)
 
-  let classNames = renderAndExtractClassnames(item, 1, 6, '.radial-list-item-content')
+  let classNames = renderAndExtractClassnames(item, '.radial-list-item-content')
   t.true(hasStyle(classNames, 'transform', 'rotate(-60deg)'))
 
-  classNames = renderAndExtractClassnames(item, 2, 6, '.radial-list-item-content')
+  item = radialListItem(<div className='test-item'>Test Item</div>, 2, 6)
+  classNames = renderAndExtractClassnames(item, '.radial-list-item-content')
   t.true(hasStyle(classNames, 'transform', 'rotate(-120deg)'))
 })
 
-const hasStyle = (classNameKeys, key, value) => {
-  return cxs.rules
-    .filter(rule => classNameKeys.includes(rule.id) && rule.css.includes(key))
-    .reduce((prev, current) => {
-      const keyValPat = `${escapeStringRegexp(key)}\\s*:\\s*${escapeStringRegexp(value)}`
-      return prev || !!current.css.match(new RegExp(keyValPat))
-    }, false)
-}
-
-const cxsClassNames = classNames => {
-  return classNames.split(' ').filter(cn => cn.includes('cxs-'))
-}
-
-const renderAndExtractClassnames = (item, index, count, selector = 'li') => {
-  const wrapper = shallow(
-    <RadialListItem
-      item={item}
-      index={index}
-      count={count}
-    />
-  )
-  return cxsClassNames(wrapper.find(selector).prop('className'))
-}
+const radialListItem = (item, index, count) => (
+  <RadialListItem
+    item={item}
+    index={index}
+    count={count}
+  />
+)

--- a/source/components/RadialListItem/index.js
+++ b/source/components/RadialListItem/index.js
@@ -1,0 +1,63 @@
+import React from 'react'
+import cxs from 'cxs'
+
+const BASE_STYLES = {
+  display: 'block',
+  zIndex: 2,
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  width: '80%',
+  height: 20,
+  margin: 0,
+  padding: 0,
+  listStyle: 'none',
+  transformOrigin: '0% 50%'
+}
+
+const SPAN_STYLES = {
+  display: 'block',
+  position: 'absolute',
+  top: 0,
+  width: '100%',
+  textAlign: 'center'
+}
+
+const RadialListItem = ({
+  item,
+  index,
+  count,
+  offsetDegrees,
+  itemStyles
+}) => {
+  const rotation = offsetDegrees + (360 / count * index)
+  const listItemStyles = Object.assign({}, BASE_STYLES, itemStyles, {
+    transform: `rotate(${rotation}deg)`
+  })
+  const spanStyles = Object.assign({}, SPAN_STYLES, {
+    transform: `rotate(${-rotation}deg)`
+  })
+
+  return (
+    <li className={`radial-list-item ${cxs(listItemStyles)}`}>
+      <span className={`radial-list-item-content ${cxs(spanStyles)}`}>
+        {item}
+      </span>
+    </li>
+  )
+}
+
+RadialListItem.propTypes = {
+  item: React.PropTypes.node.isRequired,
+  index: React.PropTypes.number.isRequired,
+  count: React.PropTypes.number.isRequired,
+  itemStyles: React.PropTypes.object,
+  offsetDegrees: React.PropTypes.number
+}
+
+RadialListItem.defaultProps = {
+  itemStyles: {},
+  offsetDegrees: 0
+}
+
+export default RadialListItem

--- a/source/components/RadialListItem/index.js
+++ b/source/components/RadialListItem/index.js
@@ -1,46 +1,29 @@
 import React from 'react'
-import cxs from 'cxs'
 
-const BASE_STYLES = {
-  display: 'block',
-  zIndex: 2,
-  position: 'absolute',
-  top: '50%',
-  left: '50%',
-  width: '80%',
-  height: 20,
-  margin: 0,
-  padding: 0,
-  listStyle: 'none',
-  transformOrigin: '0% 50%'
-}
-
-const SPAN_STYLES = {
-  display: 'block',
-  position: 'absolute',
-  top: 0,
-  width: '100%',
-  textAlign: 'center'
-}
+import css from '../../css'
+import styles from './styles'
 
 const RadialListItem = ({
   item,
   index,
   count,
-  offsetDegrees,
-  itemStyles
+  offsetDegrees = -90,
+  itemStyles = {},
+  selected = false,
+  collapsed = false
 }) => {
-  const rotation = offsetDegrees + (360 / count * index)
-  const listItemStyles = Object.assign({}, BASE_STYLES, itemStyles, {
-    transform: `rotate(${rotation}deg)`
-  })
-  const spanStyles = Object.assign({}, SPAN_STYLES, {
-    transform: `rotate(${-rotation}deg)`
-  })
+  const rotation = collapsed ? -90 : (offsetDegrees + (360 / count * index))
+  const listItemStyles = css(
+    styles.list,
+    (selected && styles.selected),
+    itemStyles,
+    { transform: `rotate(${rotation}deg)` }
+  )
+  const spanStyles = css(styles.span, { transform: `rotate(${-rotation}deg)` })
 
   return (
-    <li className={`radial-list-item ${cxs(listItemStyles)}`}>
-      <span className={`radial-list-item-content ${cxs(spanStyles)}`}>
+    <li className={`radial-list-item ${listItemStyles}`}>
+      <span className={`radial-list-item-content ${spanStyles}`}>
         {item}
       </span>
     </li>
@@ -52,12 +35,9 @@ RadialListItem.propTypes = {
   index: React.PropTypes.number.isRequired,
   count: React.PropTypes.number.isRequired,
   itemStyles: React.PropTypes.object,
-  offsetDegrees: React.PropTypes.number
-}
-
-RadialListItem.defaultProps = {
-  itemStyles: {},
-  offsetDegrees: 0
+  offsetDegrees: React.PropTypes.number,
+  selected: React.PropTypes.bool,
+  collapsed: React.PropTypes.bool
 }
 
 export default RadialListItem

--- a/source/components/RadialListItem/styles.js
+++ b/source/components/RadialListItem/styles.js
@@ -1,0 +1,29 @@
+const transition = 'transform 0.2s ease-in-out'
+
+export default {
+  list: {
+    display: 'block',
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    width: '80%',
+    height: 20,
+    margin: 0,
+    padding: 0,
+    listStyle: 'none',
+    transformOrigin: '0% 50%',
+    transition
+  },
+  label: {
+    display: 'block',
+    position: 'absolute',
+    top: 0,
+    width: '100%',
+    textAlign: 'center',
+    zIndex: 1,
+    transition
+  },
+  selected: {
+    zIndex: 3
+  }
+}

--- a/source/css.js
+++ b/source/css.js
@@ -1,0 +1,4 @@
+import cxs from 'cxs'
+import prefixer from 'inline-style-prefixer/static'
+
+export default ...rest => cxs(prefixer(Object.assign({}, ...rest)))

--- a/test/styleInspection.js
+++ b/test/styleInspection.js
@@ -1,0 +1,21 @@
+import cxs from 'cxs'
+import { shallow } from 'enzyme'
+import escapeStringRegexp from 'escape-string-regexp'
+
+export const hasStyle = (classNameKeys, key, value) => {
+  return cxs.rules
+    .filter(rule => classNameKeys.includes(rule.id) && rule.css.includes(key))
+    .reduce((prev, current) => {
+      const keyValPat = `${escapeStringRegexp(key)}\\s*:\\s*${escapeStringRegexp(value)}`
+      return prev || !!current.css.match(new RegExp(keyValPat))
+    }, false)
+}
+
+export const cxsClassNames = classNames => {
+  return classNames.split(' ').filter(cn => cn.includes('cxs-'))
+}
+
+export const renderAndExtractClassnames = (element, selector = 'li') => {
+  const wrapper = shallow(element)
+  return cxsClassNames(wrapper.find(selector).prop('className'))
+}

--- a/wallaby.config.js
+++ b/wallaby.config.js
@@ -1,6 +1,7 @@
 module.exports = wallaby => ({
   files: [
     'source/**/*.js',
+    'test/**/*.js',
     { pattern: 'source/**/__tests__/*.js', ignore: true }
   ],
 

--- a/wallaby.config.js
+++ b/wallaby.config.js
@@ -13,7 +13,7 @@ module.exports = wallaby => ({
 
   compilers: {
     '**/*.js': wallaby.compilers.babel({
-      presets: ['es2015', 'stage-0', 'react'],
+      presets: ['latest', 'react'],
       plugins: [
         require('babel-plugin-espower/create')(
           require('babel-core'), {

--- a/wallaby.config.js
+++ b/wallaby.config.js
@@ -1,0 +1,53 @@
+module.exports = wallaby => ({
+  files: [
+    'source/**/*.js',
+    { pattern: 'source/**/__tests__/*.js', ignore: true }
+  ],
+
+  tests: [
+    'source/**/__tests__/*.js'
+  ],
+
+  testFramework: 'ava',
+
+  compilers: {
+    '**/*.js': wallaby.compilers.babel({
+      presets: ['es2015', 'stage-0', 'react'],
+      plugins: [
+        require('babel-plugin-espower/create')(
+          require('babel-core'), {
+            embedAst: true,
+            patterns: require('ava/lib/enhance-assert').PATTERNS
+          }
+        )
+      ]
+    })
+  },
+
+  env: {
+    type: 'node',
+    runner: 'node'
+  },
+
+  bootstrap: () => {
+    const jsdom = require('jsdom')
+
+    const dom = jsdom.jsdom('<!doctype html><html><head></head><body></body></html>')
+
+    global.document = dom
+    global.window = dom.defaultView
+
+    propagateToGlobal(global.window)
+
+    function propagateToGlobal (window) {
+      for (let key in window) {
+        if (!window.hasOwnProperty(key)) { continue }
+        if (key in global) { continue }
+
+        global[key] = window[key]
+      }
+    }
+
+    require('babel-polyfill')
+  }
+})


### PR DESCRIPTION
This is the initial release of the `react-radial-list` component, which takes a list of renderable elements and arranges them in a circle.

We're going to use this component for the NPS tracking form @lukebrooker designed, but it's a nice little thing so I thought it'd be good to have it out on `npm`.

Note that it's styleless other than those required for positioning the elements, the README has the details for customising its look:

<img width="253" alt="screenshot 2016-10-12 11 55 22" src="https://cloud.githubusercontent.com/assets/148739/19294748/ccb46394-9072-11e6-9d44-bc59ce4242c8.png">
